### PR TITLE
Upgraded to use prop-types instead of React.proptypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "homepage": "https://github.com/WaldoJeffers/react-dc#readme",
   "dependencies": {
-    "dc": "^2.0.0"
+    "dc": "^2.0.0",
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/src/charts/composite-chart.js
+++ b/src/charts/composite-chart.js
@@ -4,8 +4,6 @@ import BaseChart from './base-chart'
 import coordinateGridMixin from '../mixins/coordinate-grid-mixin'
 import stackMixin from '../mixins/stack-mixin'
 
-const {arrayOf, bool, instanceOf, number, object, string} = React.PropTypes
-
 @coordinateGridMixin
 export default class CompositeChart extends BaseChart{
   static displayName = 'CompositeChart'

--- a/src/charts/line-chart.js
+++ b/src/charts/line-chart.js
@@ -5,8 +5,6 @@ import coordinateGridMixin from '../mixins/coordinate-grid-mixin'
 import stackMixin from '../mixins/stack-mixin'
 import lineMixin from '../mixins/line-mixin'
 
-const {arrayOf, bool, func, number, oneOfType, shape, string} = React.PropTypes
-
 @stackMixin
 @coordinateGridMixin
 @lineMixin

--- a/src/charts/pie-chart.js
+++ b/src/charts/pie-chart.js
@@ -6,8 +6,6 @@ import capMixin from '../mixins/cap-mixin'
 import colorMixin from '../mixins/color-mixin'
 import pieMixin from '../mixins/pie-mixin'
 
-const {bool, number, string} = React.PropTypes
-
 @pieMixin
 @colorMixin
 @capMixin

--- a/src/charts/row-chart.js
+++ b/src/charts/row-chart.js
@@ -7,8 +7,6 @@ import capMixin from '../mixins/cap-mixin'
 import colorMixin from '../mixins/color-mixin'
 import rowMixin from '../mixins/row-mixin'
 
-const {any, bool, number, oneOfType} = React.PropTypes
-
 @rowMixin
 @colorMixin
 @capMixin

--- a/src/mixins/bar-mixin.js
+++ b/src/mixins/bar-mixin.js
@@ -1,7 +1,6 @@
 import React from 'react'
+import {bool, number} from 'prop-types'
 import {withProps} from '../utils'
-
-const {bool, number} = React.PropTypes
 
 export default withProps({
   alwaysUseRounding: bool,

--- a/src/mixins/base-mixin.js
+++ b/src/mixins/base-mixin.js
@@ -1,7 +1,6 @@
 import React from 'react'
+import {any, bool, func, number, object, oneOfType, shape, string} from 'prop-types'
 import {withProps} from '../utils'
-
-const {any, bool, func, number, object, oneOfType, shape, string} = React.PropTypes
 
 const groupShape = shape({
   all : func

--- a/src/mixins/cap-mixin.js
+++ b/src/mixins/cap-mixin.js
@@ -1,7 +1,6 @@
 import React from 'react'
+import {func, bool, number, oneOfType, string} from 'prop-types'
 import {withProps} from '../utils'
-
-const {func, bool, number, oneOfType, string} = React.PropTypes
 
 export default withProps({
   cap: number,

--- a/src/mixins/color-mixin.js
+++ b/src/mixins/color-mixin.js
@@ -1,7 +1,6 @@
 import React from 'react'
+import {arrayOf, func, number, string} from 'prop-types'
 import {withProps} from '../utils'
-
-const {arrayOf, func, number, string} = React.PropTypes
 
 export default withProps({
   colorAccessor: func,

--- a/src/mixins/composite-mixin.js
+++ b/src/mixins/composite-mixin.js
@@ -1,7 +1,6 @@
 import React from 'react'
+import {arrayOf, bool, object, oneOfType, shape, string} from 'prop-types'
 import withProps from '../utils.js'
-
-const {arrayOf, bool, object, oneOfType, shape, string} = React.PropTypes
 
 export default withProps({
   alignYAxes: bool,

--- a/src/mixins/coordinate-grid-mixin.js
+++ b/src/mixins/coordinate-grid-mixin.js
@@ -1,10 +1,9 @@
 import React from 'react'
-import {compose, withProps} from '../utils'
 import colorMixin from './color-mixin'
 import marginMixin from './margin-mixin'
 import baseMixin from './base-mixin'
-
-const {any, array, arrayOf, bool, func, instanceOf, number, oneOfType, shape, string} = React.PropTypes
+import {any, array, arrayOf, bool, func, instanceOf, number, oneOfType, shape, string} from 'prop-types'
+import {compose, withProps} from '../utils'
 
 const coordinateGridMixin = withProps({
   brushOn: bool,

--- a/src/mixins/line-mixin.js
+++ b/src/mixins/line-mixin.js
@@ -1,7 +1,6 @@
 import React from 'react'
+import {arrayOf, bool, func, number, oneOfType, shape, string} from 'prop-types'
 import {withProps} from '../utils'
-
-const {arrayOf, bool, func, number, oneOfType, shape, string} = React.PropTypes
 
 export default withProps({
   dashStyle: arrayOf(number),

--- a/src/mixins/margin-mixin.js
+++ b/src/mixins/margin-mixin.js
@@ -1,11 +1,12 @@
 import React from 'react'
+import {shape, number} from 'prop-types'
 import {withProps} from '../utils'
 
 export default withProps({
-  margins: React.PropTypes.shape({
-    left: React.PropTypes.number.isRequired,
-    right: React.PropTypes.number.isRequired,
-    top: React.PropTypes.number.isRequired,
-    bottom: React.PropTypes.number.isRequired
+  margins: shape({
+    left: number.isRequired,
+    right: number.isRequired,
+    top: number.isRequired,
+    bottom: number.isRequired
   })
 })

--- a/src/mixins/pie-mixin.js
+++ b/src/mixins/pie-mixin.js
@@ -1,7 +1,6 @@
 import React from 'react'
+import {bool, number, string} from 'prop-types'
 import {withProps} from '../utils'
-
-const {bool, number, string} = React.PropTypes
 
 export default withProps({
   cx: number,

--- a/src/mixins/row-mixin.js
+++ b/src/mixins/row-mixin.js
@@ -1,7 +1,6 @@
 import React from 'react'
+import {any, bool, number, oneOfType} from 'prop-types'
 import {withProps} from '../utils'
-
-const {any, bool, number, oneOfType} = React.PropTypes
 
 export default withProps({
   elasticX: bool,

--- a/src/mixins/scatter-mixin.js
+++ b/src/mixins/scatter-mixin.js
@@ -1,7 +1,6 @@
 import React from 'react'
+import {bool, func, number, oneOfType, string} from 'prop-types'
 import {withProps} from '../utils'
-
-const {bool, func, number, oneOfType, string} = React.PropTypes
 
 export default withProps({
   emptySize: number,

--- a/src/mixins/series-mixin.js
+++ b/src/mixins/series-mixin.js
@@ -1,7 +1,6 @@
 import React from 'react'
+import {func} from 'prop-types'
 import {withProps} from '../utils'
-
-const {func} = React.PropTypes
 
 export default withProps({
   chart: func,

--- a/src/mixins/stack-mixin.js
+++ b/src/mixins/stack-mixin.js
@@ -1,7 +1,6 @@
 import React from 'react'
+import {arrayOf, bool, func, oneOfType, shape, string} from 'prop-types'
 import {withProps} from '../utils'
-
-const {arrayOf, bool, func, oneOfType, shape, string} = React.PropTypes
 
 const groupShape = shape({
   all : func


### PR DESCRIPTION
@WaldoJeffers The current source code wasn't building since it was still dependent on React.proptypes. I have updated it to use prop-types.